### PR TITLE
Fix #156

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -98,7 +98,11 @@ const webpackConfig = merge(baseWebpackConfig, {
         to: config.build.assetsSubDirectory,
         ignore: ['.*']
       }
-    ])
+    ]),
+    new webpack.ProvidePlugin({
+      Promise: 'bluebird'
+    }),
+    new webpack.NormalModuleReplacementPlugin(/es6-promise$/, 'bluebird')
   ]
 })
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,8 @@
 import Vue from 'vue'
 import App from './App'
 import router from './router'
-import { polyfillLoader } from 'polyfill-io-feature-detection'
-import { polyfill } from 'es6-promise'
 import 'bulma/css/bulma.css'
 import 'font-awesome/css/font-awesome.css'
-
-polyfill()
 
 Vue.config.productionTip = false
 
@@ -17,9 +13,4 @@ let main = new Vue({
   router,
   template: '<App/>',
   components: { App }
-})
-
-polyfillLoader({
-  'features': 'Promise,fetch',
-  'onCompleted': main
 })


### PR DESCRIPTION
# Beskrivning

Beroendet i main.js av es6-promise har tagits bort och paketerats in som plugin i webpack.prod.conf.js.

Fixar #156

## Typ av ändring

Ta bort alternativ som inte är relevanta.

- [x] Bugg fix (icke-brytande förändring som åtgärdar ett problem)

# Hur har detta blivit testat?
- [X ] Mozilla Firefox 
- [X] Internet Explorer 11
- [X] Microsoft Edge
- [X] Safari
- [X] Google Chrome

**Testkonfiguration**:
* Operativsystem: macOS för Safari och Chrome; windows 10 via vmware för IE11 och Edge.

# Checklista:

- [x] Min kod följer stilriktlinjerna för detta projekt
- [x] Jag har utfört en egen granskning av min egen kod
- [x] Mina ändringar genererar inga nya varningar
