### PR TITLE
Fix #177

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "node build/dev-server.js",
-    "start": "npm run dev",
+    "start": "npm run backend & npm run front",
     "build": "node build/build.js",
     "backend": "node backend/server.js",
     "watch": "start npm-watch backend && npm run dev",


### PR DESCRIPTION
# Beskrivning

Åtgärdar dubbletten `npm run start` så att den kör igång back-end och front-end.

Fixar #177

## Typ av ändring
- [x] Denna ändring kräver en dokumentationsuppdatering: _De dokument, om de existerar, som beskriver vad `npm run start` gör behöver uppdateras._