### PR TITLE
Uppdaterat JSON-svar vid sökning, samt sidhämtning (pagination) med h.a. query parametrar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ selenium-debug.log
 *.njsproj
 *.sln
 *.db
+package-lock.json

--- a/backend/routes/components.js
+++ b/backend/routes/components.js
@@ -43,8 +43,7 @@ router.route('/search/:id')
 router.route('/pending/search/:id')
   .get((req, res) => {
     // precondition: parameter is wellformed
-    console.log('Called /pending/search with id: ' + req.params.id);
-    
+    console.log('Called /pending/search with id: ' + req.params.id)
     let response = initPayload()
     let offset = parseInt(+req.query.offset) || 0
     let amount = parseInt(+req.query.amount) || 5
@@ -459,21 +458,9 @@ router.route('/log/:id')
   // postcondition: the log entries of the component
 })
 
-function validateSearchParameter (params) {
-  return true
-}
-
 // ----------------------------------------------------------------------------
 //  Methods for /components/search/:id
 // ---------------------------------------------------------------------------_
-
-
-/*
-router.route('/pending/search/:id').get(
-  (req, res) => {
-
-  })
-*/
 
 function getComponent (req, res, componentName, componentVersion, id, callback) {
   let query = 'SELECT * FROM components'

--- a/backend/routes/components.js
+++ b/backend/routes/components.js
@@ -1,48 +1,93 @@
+let initPayload = require('./payloadConfig')
 var express = require('express')
 var router = express.Router()
 
 // ----------------------------------------------------------------------------
 //  Methods for /components
 // ----------------------------------------------------------------------------
-router.route('/')
+/**
+ *
+ * @param db - the sqlite3 database to connect to
+ * @param offset - offset into the database table
+ * @param amount - amount of objects to retrieve
+ * @param response - response object, given to you from the initPayload() function
+ * @param setLinksCB - callback used to set the context-data of the response object.
+ */
+function getLinkData (db, offset, amount, response, signed, setLinksCB) {
+  // FIXME: getTotal(req, response) doesn't work because of the async nature of calls to sqlite3
+  const pageCountQuery = (signed) ? `select count(*) as count from components where approved=1` : `select count(*) as count from components where approved=0`
+  console.log(pageCountQuery)
+  db.get(pageCountQuery, (err, row) => {
+    if (err) {
+      console.log(err)
+      response = initPayload()
+      response.error.message.push('Could not get element count from database.')
+      response.errorflag = true
+      response.meta.count = 0
+    } else {
+      // response.meta.count = Number.isSafeInteger(row.count) ? row.count : 0
+      // Object.assign(response.meta, meta)
+      response.meta.count = row.count
+      console.log("Total is: " + row.count)
+      // if these parameters are malformed, the response defaults to the first 30 items (0, 30)
 
-  .get((req, res) => {
-    let currentPage = 0
-    if (typeof req.query.totalElements !== 'undefined') {
-      const pageCountQuery = `select count(*) as rowCount from components`
-      req.db.all(pageCountQuery, (err, rows) => {
-        if (err) {
-          console.log(err)
-        } else {
-          res.json(rows[0])
+      if (isNaN(offset) || isNaN(amount)) {
+        let links = {
+          prev: 0,
+          current: 0,
+          next: (0 + amount) < response.meta.count ? amount : 0
         }
-      })
-      return
+        console.log("Next " + links.next)
+        response.errorflag = true
+        response.error.message.push('Illegal query parameters passed')
+        setLinksCB(links)
+      } else if (Number.isSafeInteger(offset) && Number.isSafeInteger(amount)) {
+        let links = {
+          prev: (offset - amount) > 0 ? (offset - amount) : 0,
+          current: offset,
+          next: (offset + amount) < response.meta.count ? (offset + amount) : (response.meta.count)
+        }
+        console.log("Next is a num and is: " + links.next)
+        setLinksCB(links)
+      }
     }
-    if (typeof req.query.page !== 'undefined' && typeof req.query.amount !== 'undefined') {
-      currentPage = +req.query.page
-      const amount = +req.query.amount
-      let offset = (currentPage) * amount
-      const query = `SELECT * FROM components ORDER BY components.componentName LIMIT ${offset}, ${amount}`
-      console.log(query)
+  })
+}
+
+router.route('/')
+  .get((req, res) => {
+    // if these parameters are malformed, the response defaults to the first 30 items (0, 30)
+    let response = initPayload()
+    let offset = parseInt(+req.query.offset) || 0
+    let amount = parseInt(+req.query.amount) || 5
+    // exempel på route /components med query:
+    // /components/?offset=250&amount=25
+    // ?-tecknet berättar att det som kommer efter är query-strängen,
+    // dessa parametrar finns i req.query (req skickas med i .get((req...
+    getLinkData(req.db, offset, amount, response, true, (links) => {
+      response.links = {
+        prev: `?offset=${links.prev}&amount=${amount}`,
+        current: `?offset=${links.current}&amount=${amount}`,
+        next: `?offset=${links.next}&amount=${amount}`
+      }
+    })
+    if (!response.errorflag) {
+      // since req.query.offset and amount has been passed through parseInt, isNan and isSafeNumber, errorFlag is not set
+      const query = `SELECT * FROM components where approved=1 LIMIT ${offset}, ${amount}`
       req.db.all(query, (err, rows) => {
         if (err) {
-          console.log(err)
+          response.error.message = [...err]
+          response.error.status = 'ERROR'
+          response.error.errorflag = true
+          res.json(response)
         } else {
-          res.json(rows)
+          response.items = rows
+          res.json(response)
         }
-      })
-    } else {
-      console.log("Motherfucker")
-      req.db.all('SELECT * FROM components', (err, rows) => {
-        if (err) {
-          console.log(err)
-        } else {
-          res.json(rows)
-        }
+        // = rows
+        response.errors.status = 'OK' // FIXME: Perhaps not a necessary attribute ?
       })
     }
-
   })
 
 // ----------------------------------------------------------------------------
@@ -93,12 +138,12 @@ function setComponentComment (req, res, input) {
 //  Methods for /components/approve
 // ----------------------------------------------------------------------------
 
-function validateRequest(component, approved) {
-  console.log("Validating data")
+function validateRequest (component, approved) {
+  console.log('Validating data')
   return ((approved[0] == null && approved[1] == null) || ((component.approved == 1 && approved[0] == 0) || (component.approved != 1 && approved[1] != '')))
 }
 
-function getCorrectApproved(input) {
+function getCorrectApproved (input) {
   let approved = [null, null]
 
   if (input.hasOwnProperty('approved')) {
@@ -115,7 +160,7 @@ function getCorrectApproved(input) {
     }
   }
 
-  //logic for correct approve/approvedBy
+  // logic for correct approve/approvedBy
   if (approved[0] != null) {
     if (approved == 0 && approved[1] == null) {
       approved[1] = ''
@@ -126,14 +171,12 @@ function getCorrectApproved(input) {
   return approved
 }
 
-
 router.route('/pending')
   .get((req, res) => {
-    req.db.all("SELECT * FROM components where approved=0", (err, rows) => {
+    req.db.all('SELECT * FROM components where approved=0', (err, rows) => {
       if (err) {
         console.log(err)
       } else {
-        console.log(rows)
         res.json(rows)
       }
     })
@@ -145,23 +188,21 @@ router.route('/approve')
     const input = req.body
     let approved = getCorrectApproved(input)
 
-    //Get component to make sure that it is not approved already
+    // Get component to make sure that it is not approved already
     getComponent(req, res, null, null, input.id, function (component) {
-      //Make sure that row is not null and that an approved component can't be approved again by a diffrent person
+      // Make sure that row is not null and that an approved component can't be approved again by a diffrent person
       if (component != null && input.id != null && validateRequest(component, approved)) {
-
-        //update the component
+        // update the component
         updateComponent(req, res, null, null, input.id, ['approved', 'approvedBy'], approved, function () {
           insertUpdateIntoLog(req, res, component.id, approved)
         })
-
-      }//Else throw an error
+      }// Else throw an error
       else {
         let message
         message = {
-          "errorType": "alreadySigned",
-          "byUser": "" + component.approvedBy
-          //"onTime": "1510062744"
+          'errorType': 'alreadySigned',
+          'byUser': '' + component.approvedBy
+          // "onTime": "1510062744"
         }
         console.log(message)
         res.status(500).send(message)
@@ -184,11 +225,11 @@ router.route('/add')
             console.log(error.message)
             res.status(500)
             req.db.run('rollback')
-            res.send("ERROR! error message:" + error.message + ", query: " + query)
+            res.send('ERROR! error message:' + error.message + ', query: ' + query)
           } else {
             // Get the component so that the id can be extracted
             getComponent(req, res, req.body.componentName, req.body.componentVersion, null, function (component) {
-              insertComponentLog(req, res, component.id, "Component created.",
+              insertComponentLog(req, res, component.id, 'Component created.',
                 function (returnValue) {
                   licenses.forEach((license) => insertLicenseIntoComponent(req, res, license, component.id, (succeeded) => {
                     if (!succeeded) {
@@ -198,7 +239,7 @@ router.route('/add')
                     }
                   }))
                   req.db.run('commit')
-                  res.status(201).send("Success!")
+                  res.status(201).send('Success!')
                 })
             })
           }
@@ -223,23 +264,23 @@ router.route('/connectLicenseWithComponent')
     const input = req.body
 
     if (input.licenseID != null && input.componentID != null) {
-      //Insert the provided license into the component
+      // Insert the provided license into the component
       insertLicenseIntoComponent(req, res, input.licenseID, input.componentID, function (returnValue) {
-        //Get the license that was inserted
+        // Get the license that was inserted
         getLicense(req, res, null, null, input.licenseID, function (license) {
           if (license == null) {
             message = {
-              "errorType": "licenseDoesNotExist"
+              'errorType': 'licenseDoesNotExist'
             }
             console.log(message)
             res.status(500).send(message)
           } else {
-            //Create a log of the license added to the component
-            insertComponentLog(req, res, input.componentID, "Added license: " + license.licenseName + " v" + license.licenseVersion + ".",
+            // Create a log of the license added to the component
+            insertComponentLog(req, res, input.componentID, 'Added license: ' + license.licenseName + ' v' + license.licenseVersion + '.',
               function (returnValue) {
                 updateComponent(req, res, null, null, input.componentID, ['approved', 'approvedBy'], ['0', ''], function (returnValue) {
-                  res.status(200).send("Success")
-                });
+                  res.status(200).send('Success')
+                })
               })
           }
         })
@@ -256,7 +297,7 @@ router.route('/componentsInProduct/:id')
     // precondition: product exists and it has components connected to it..
     let input = req.params.id
     if (input != null) {
-      //Get components from the product
+      // Get components from the product
       getComponentsFromProduct(req, res, input)
     }
     // postcondition: components connected to the product.
@@ -271,7 +312,7 @@ router.route('/componentsInProject/:id')
     let input = req.params.id
 
     if (input != null) {
-      //Get components from the product
+      // Get components from the product
       getComponentsFromProject(req, res, input)
     }
     // postcondition: components connected to the project.
@@ -286,7 +327,7 @@ router.route('/componentsWithLicense/:id')
   let input = req.params.id
 
   if (input != null) {
-    //Get components from the product
+    // Get components from the product
     getComponentsWithLicense(req, res, input)
   }
   // postcondition: components with license connected to it.
@@ -300,14 +341,14 @@ router.route('/log/:id')
   // precondition: component exists.
   let input = req.params.id
   if (input != null) {
-    //Get the component log
+    // Get the component log
     getComponentLog(req, res, input)
   }
   // postcondition: the log entries of the component
 })
 
-function validateSearchParameter(params) {
-  return true;
+function validateSearchParameter (params) {
+  return true
 }
 
 // ----------------------------------------------------------------------------
@@ -323,7 +364,7 @@ router.route('/search/:id')
       if (err) {
         console.log(err)
         res.status(404)
-        res.send("ERROR! error message:" + err.message + ", query: " + query)
+        res.send('ERROR! error message:' + err.message + ', query: ' + query)
       } else {
         res.status(200)
         console.log(rows)
@@ -345,7 +386,7 @@ router.route('/:id')
       if (err) {
         console.log(err)
         res.status(404)
-        res.send("ERROR! error message:" + err.message + ", query: " + query)
+        res.send('ERROR! error message:' + err.message + ', query: ' + query)
       } else {
         res.status(200)
         res.json(row)
@@ -353,15 +394,15 @@ router.route('/:id')
     })
   })
 
-function getComponent(req, res, componentName, componentVersion, id, callback) {
-  let query = "SELECT * FROM components"
+function getComponent (req, res, componentName, componentVersion, id, callback) {
+  let query = 'SELECT * FROM components'
   let parameters = []
   if (componentName != null && componentVersion != null) {
-    query += " WHERE componentName = ? AND componentVersion = ?;"
+    query += ' WHERE componentName = ? AND componentVersion = ?;'
     parameters.push(componentName)
     parameters.push(componentVersion)
   } else if (id != null) {
-    query += " WHERE id = ?;"
+    query += ' WHERE id = ?;'
     parameters.push(id)
   }
 
@@ -369,33 +410,32 @@ function getComponent(req, res, componentName, componentVersion, id, callback) {
     if (error) {
       console.log(error.message)
       res.status(500)
-      res.send("ERROR! error message:" + error.message + ", query: " + query + ", parameters: " + parameters)
+      res.send('ERROR! error message:' + error.message + ', query: ' + query + ', parameters: ' + parameters)
     } else {
       if (row != null) {
-        callback(row);
-      } else callback(null);
+        callback(row)
+      } else callback(null)
     }
   })
 }
 
-//Get component in product
-function getComponentsFromProduct(req, res, id) {
-  let query = "SELECT componentID AS id , componentName, componentVersion, dateCreated, lastEdited, comment, approved, approvedBy "
-    + "FROM "
-    + "components "
-    + "INNER JOIN "
-    + "componentsInProducts "
-    + "ON "
-    + "components.id=componentsInProducts.componentID "
-    + "WHERE "
+// Get component in product
+function getComponentsFromProduct (req, res, id) {
+  let query = 'SELECT componentID AS id , componentName, componentVersion, dateCreated, lastEdited, comment, approved, approvedBy ' +
+    'FROM ' +
+    'components ' +
+    'INNER JOIN ' +
+    'componentsInProducts ' +
+    'ON ' +
+    'components.id=componentsInProducts.componentID ' +
+    'WHERE '
 
-  query += "productID = ?;"
-
+  query += 'productID = ?;'
 
   req.db.all(query, [id], (err, rows) => {
     if (err) {
       // If there's an error then provide the error message and the different attributes that could have caused it.
-      res.send("ERROR! error message:" + err.message + ", query: " + query)
+      res.send('ERROR! error message:' + err.message + ', query: ' + query)
     } else {
       console.log(rows)
       res.json(rows)
@@ -403,69 +443,66 @@ function getComponentsFromProduct(req, res, id) {
   })
 }
 
-//Get component in project
-function getComponentsFromProject(req, res, id) {
-  let query = "SELECT DISTINCT componentID AS id, componentName, componentVersion, dateCreated, lastEdited, comment, approved, approvedBy FROM components LEFT OUTER JOIN componentsInProducts ON components.id=componentsInProducts.componentID" +
-  " LEFT OUTER JOIN productsInProjects ON productsInProjects.productID=componentsInProducts.productID WHERE "
+// Get component in project
+function getComponentsFromProject (req, res, id) {
+  let query = 'SELECT DISTINCT componentID AS id, componentName, componentVersion, dateCreated, lastEdited, comment, approved, approvedBy FROM components LEFT OUTER JOIN componentsInProducts ON components.id=componentsInProducts.componentID' +
+  ' LEFT OUTER JOIN productsInProjects ON productsInProjects.productID=componentsInProducts.productID WHERE '
 
-query += "projectID = ?;"
-
+  query += 'projectID = ?;'
 
   req.db.all(query, [id], (err, rows) => {
     if (err) {
       // If there's an error then provide the error message and the different attributes that could have caused it.
-      res.send("ERROR! error message:" + err.message + ", query: " + query)
-    } else
-      res.send(rows)
+      res.send('ERROR! error message:' + err.message + ', query: ' + query)
+    } else { res.send(rows) }
   })
 }
 
-//Get components with license
-function getComponentsWithLicense(req, res, id) {
-  let query = "SELECT componentID AS id , componentName, componentVersion, dateCreated, lastEdited, comment, approved, approvedBy "
-    + "FROM "
-    + "components "
-    + "INNER JOIN "
-    + "licensesInComponents "
-    + "ON "
-    + "components.id=licensesInComponents.componentID "
-    + "WHERE "
+// Get components with license
+function getComponentsWithLicense (req, res, id) {
+  let query = 'SELECT componentID AS id , componentName, componentVersion, dateCreated, lastEdited, comment, approved, approvedBy ' +
+    'FROM ' +
+    'components ' +
+    'INNER JOIN ' +
+    'licensesInComponents ' +
+    'ON ' +
+    'components.id=licensesInComponents.componentID ' +
+    'WHERE '
 
-  query += "licenseID = ?;"
-
+  query += 'licenseID = ?;'
 
   req.db.all(query, [id], (err, rows) => {
     if (err) {
       // If there's an error then provide the error message and the different attributes that could have caused it.
-      res.send("ERROR! error message:" + err.message + ", query: " + query)
+      res.send('ERROR! error message:' + err.message + ', query: ' + query)
     } else {
       res.json(rows)
     }
   })
 }
 
-//Update the component
-function updateComponent(req, res, componentName, componentVersion, id, parametersText, parameters, callback) {
-  let query = "UPDATE components SET "
+// Update the component
+function updateComponent (req, res, componentName, componentVersion, id, parametersText, parameters, callback) {
+  let query = 'UPDATE components SET '
 
-  //Construct the remaining SQL query
-  let first = false;
+  // Construct the remaining SQL query
+  let first = false
   for (let i = 0; i < parametersText.length; i++) {
     if (!first) {
       first = true
-      query += parametersText[i] + " = ?"
+      query += parametersText[i] + ' = ?'
     } else {
-      query += ", " + parametersText[i] + " = ?"
+      query += ', ' + parametersText[i] + ' = ?'
     }
   }
 
-  //Check if either componentName/componentVersion or id was provided and use them one find the row to alter
+  // Check if either componentName/componentVersion or id was provided and use them one find the row to alter
   if (componentName != null && componentVersion != null) {
-    query += " WHERE componentName = ? AND componentVersion = ?;"
+    query += ' WHERE componentName = ? AND componentVersion = ?;'
     parameters.push(componentName)
     parameters.push(componentVersion)
   } else if (id != null) {
-    query += " WHERE id = ?;"
+    query += ' WHERE id = ?;'
     parameters.push(id)
   }
 
@@ -473,17 +510,17 @@ function updateComponent(req, res, componentName, componentVersion, id, paramete
     if (error) {
       console.log(error.message)
       res.status(500)
-      res.send("ERROR! error message:" + error.message + ", query: " + query + ", parameters: " + parameters)
+      res.send('ERROR! error message:' + error.message + ', query: ' + query + ', parameters: ' + parameters)
     } else {
       callback(true)
     }
   })
 }
 
-//insert a license into a component
-function insertLicenseIntoComponent(req, res, licenseID, componentID, callback) {
-  //Insert the license as a license of the component
-  let query = "INSERT INTO licensesInComponents ( licenseID, componentID) VALUES (?, ?);"
+// insert a license into a component
+function insertLicenseIntoComponent (req, res, licenseID, componentID, callback) {
+  // Insert the license as a license of the component
+  let query = 'INSERT INTO licensesInComponents ( licenseID, componentID) VALUES (?, ?);'
   let parameters = [licenseID, componentID]
   req.db.run(query, parameters, (error) => {
     if (error) {
@@ -491,21 +528,21 @@ function insertLicenseIntoComponent(req, res, licenseID, componentID, callback) 
       res.status(500)
       res.send(error.message)
     } else {
-      callback(true);
+      callback(true)
     }
   })
 }
 
-//Get a license
-function getLicense(req, res, licenseName, licenseVersion, id, callback) {
-  let query = "SELECT * FROM licenses"
+// Get a license
+function getLicense (req, res, licenseName, licenseVersion, id, callback) {
+  let query = 'SELECT * FROM licenses'
   let parameters = []
   if (licenseName != null && licenseVersion != null) {
-    query += " WHERE licenseName = ? AND licenseVersion = ?;"
+    query += ' WHERE licenseName = ? AND licenseVersion = ?;'
     parameters.push(licenseName)
     parameters.push(licenseVersion)
   } else if (id != null) {
-    query += " WHERE id = ?;"
+    query += ' WHERE id = ?;'
     parameters.push(id)
   }
 
@@ -513,63 +550,62 @@ function getLicense(req, res, licenseName, licenseVersion, id, callback) {
     if (error) {
       console.log(error.message)
       res.status(500)
-      res.send("ERROR! error message:" + error.message + ", query: " + query + ", parameters: " + parameters)
+      res.send('ERROR! error message:' + error.message + ', query: ' + query + ', parameters: ' + parameters)
     } else {
       if (row != null) {
-        callback(row);
-      } else callback(null);
+        callback(row)
+      } else callback(null)
     }
   })
 }
 
-//Insert a new row into componentLog
-function insertComponentLog(req, res, id, text, callback) {
+// Insert a new row into componentLog
+function insertComponentLog (req, res, id, text, callback) {
   let parametersLog = [id, new Date().toLocaleDateString(), text]
-  let queryLog = "INSERT INTO componentLog (componentID, dateLogged, note) VALUES (?, ?, ?);"
+  let queryLog = 'INSERT INTO componentLog (componentID, dateLogged, note) VALUES (?, ?, ?);'
   req.db.run((queryLog), parametersLog, (error) => {
     if (error) {
       console.log(error.message)
       res.status(500)
       res.send(error.message)
     } else {
-      callback(true);
+      callback(true)
     }
   })
 }
 
-//Insert the update into the ComponentLog
-function insertUpdateIntoLog(req, res, correctInputId, approved, comment) {
-
-  //If the comment was changed then log it
-  if(comment != null){
-    insertComponentLog(req, res, correctInputId, "Comment was changed to: " + comment + ".", function (log) {
+// Insert the update into the ComponentLog
+function insertUpdateIntoLog (req, res, correctInputId, approved, comment) {
+  // If the comment was changed then log it
+  if (comment != null) {
+    insertComponentLog(req, res, correctInputId, 'Comment was changed to: ' + comment + '.', function (log) {
     })
   }
-  //If approve has changed then log it
+  // If approve has changed then log it
   if (req.body.hasOwnProperty('approved')) {
     if (approved[0] == 0) {
-      insertComponentLog(req, res, correctInputId, "Component changed to not approved.", function (log) {
+      insertComponentLog(req, res, correctInputId, 'Component changed to not approved.', function (log) {
       })
     } else if (approved[0] == 1) {
-      insertComponentLog(req, res, correctInputId, "Component changed to approved by " + approved[1] + ".", function (log) {
+      insertComponentLog(req, res, correctInputId, 'Component changed to approved by ' + approved[1] + '.', function (log) {
       })
     }
-  }//If approveBy has changed then log it
+  }// If approveBy has changed then log it
   else if (req.body.hasOwnProperty('approvedBy')) {
     if (approved[1] == '') {
-      insertProductLog(req, res, correctInputId, "Component changed to not approved.", function (log) {
+      insertProductLog(req, res, correctInputId, 'Component changed to not approved.', function (log) {
       })
     } else if (approved[1] != '') {
-      insertComponentLog(req, res, correctInputId, "Component changed to approved by " + approved[1] + ".", function (log) {
+      insertComponentLog(req, res, correctInputId, 'Component changed to approved by ' + approved[1] + '.', function (log) {
       })
     }
   }
   res.status(204).send('success')
 }
 
-//Get component log
-function getComponentLog(req, res, id){
-  let query = "SELECT * FROM componentLog WHERE componentID = ?"
+// Get component log
+function getComponentLog (req, res, id) {
+  let query = 'SELECT * FROM componentLog WHERE componentID = ?'
 
   req.db.all(query, [id], (error, rows) => {
     if (error) {

--- a/backend/routes/components.js
+++ b/backend/routes/components.js
@@ -5,6 +5,7 @@ var router = express.Router()
 router.route('/search/:id')
   .get((req, res) => {
     // precondition: parameter is wellformed
+    console.log('Called /search with the id: ' + req.params.id)
     let response = initPayload()
     let offset = parseInt(+req.query.offset) || 0
     let amount = parseInt(+req.query.amount) || 5
@@ -42,6 +43,8 @@ router.route('/search/:id')
 router.route('/pending/search/:id')
   .get((req, res) => {
     // precondition: parameter is wellformed
+    console.log('Called /pending/search with id: ' + req.params.id);
+    
     let response = initPayload()
     let offset = parseInt(+req.query.offset) || 0
     let amount = parseInt(+req.query.amount) || 5
@@ -257,6 +260,7 @@ function getCorrectApproved (input) {
 
 router.route('/pending')
   .get((req, res) => {
+    console.log('Called /pending')
     let response = initPayload()
     let offset = parseInt(+req.query.offset) || 0
     let amount = parseInt(+req.query.amount) || response.links.getDefaultAmount()
@@ -721,13 +725,12 @@ function setComponentLog (req, res, input, old, callback) {
 }
 
 // ----------------------------------------------------------------------------
-//  Methods for /components/:id
+//  Methods for /components/component/:id
 // ----------------------------------------------------------------------------
 router.route('/component/:id')
 
 // In order to search; send in a JSON object with the applicable parameters.
   .get((req, res) => {
-    console.log("Cunt")
     let input = req.params.id
     const query = `SELECT * FROM components WHERE id=${input}`
     req.db.get(query, (err, row) => {

--- a/backend/routes/components.js
+++ b/backend/routes/components.js
@@ -2,6 +2,9 @@ let [initPayload] = require('./payloadConfig')
 var express = require('express')
 var router = express.Router()
 
+// ===========================
+// Methods for /components/search/:id
+// ===========================
 router.route('/search/:id')
   .get((req, res) => {
     // precondition: parameter is wellformed
@@ -40,6 +43,9 @@ router.route('/search/:id')
     }
   })
 
+// ===========================
+// Methods for searching, /components/search/:id
+// ===========================
 router.route('/pending/search/:id')
   .get((req, res) => {
     // precondition: parameter is wellformed
@@ -79,18 +85,13 @@ router.route('/pending/search/:id')
 // ----------------------------------------------------------------------------
 //  Methods for /components
 // ----------------------------------------------------------------------------
-
-function setCountQuery() {
-
-}
-
 /**
- *
+ * setLinksCB is a call back
  * @param db - the sqlite3 database to connect to
  * @param offset - offset into the database table
  * @param amount - amount of objects to retrieve
  * @param response - response object, given to you from the initPayload() function
- * @param setLinksCB - callback used to set the context-data of the response object.
+ * @param setLinksCB - callback used to set the context-data of the response object. (the links-part, of the payload-object)
  */
 function getLinkData (db, offset, amount, response, pageQuery, setLinksCB) {
   // FIXME: getTotal(req, response) doesn't work because of the async nature of calls to sqlite3
@@ -157,6 +158,7 @@ router.route('/')
         next: `?offset=${links.next}&amount=${amount}`
       }
     })
+
     if (!response.errorflag) {
       // since req.query.offset and amount has been passed through parseInt, isNan and isSafeNumber, errorFlag is not set
       const query = `SELECT * FROM components where approved=1 LIMIT ${offset}, ${amount}`
@@ -173,6 +175,7 @@ router.route('/')
         }
         // = rows
       })
+
     }
   })
 
@@ -257,9 +260,12 @@ function getCorrectApproved (input) {
   return approved
 }
 
+
+// ----------------------------------------------------------------------------
+//  Methods for /components/pending
+// ----------------------------------------------------------------------------
 router.route('/pending')
   .get((req, res) => {
-    console.log('Called /pending')
     let response = initPayload()
     let offset = parseInt(+req.query.offset) || 0
     let amount = parseInt(+req.query.amount) || response.links.getDefaultAmount()
@@ -293,6 +299,10 @@ router.route('/pending')
     }
   })
 
+
+// ----------------------------------------------------------------------------
+//  Methods for /components/approve
+// ----------------------------------------------------------------------------
 router.route('/approve')
   .put((req, res) => {
     // precondition: check that id == OK, signature == OK and that component hasn't yet been signed

--- a/backend/routes/payloadConfig.js
+++ b/backend/routes/payloadConfig.js
@@ -1,0 +1,25 @@
+function initPayload () {
+  const payload = {
+    items: [],
+    links: {
+      prev: '',
+      current: `?offset=0&amount=${25}`,
+      next: `?offset=0&amount=${25}`,
+      getDefaultAmount: function () {
+        return 25
+      }
+    },
+    meta: {
+      current: 0,
+      count: 0
+    },
+    errors: {
+      message: [],
+      status: 'OK'
+    },
+    errorflag: false
+  }
+  return payload
+}
+
+module.exports = initPayload

--- a/backend/routes/payloadConfig.js
+++ b/backend/routes/payloadConfig.js
@@ -7,10 +7,7 @@ function initPayload () {
     links: {
       prev: '',
       current: `?offset=0&amount=${3}`,
-      next: `?offset=0&amount=${3}`,
-      getDefaultAmount: function () {
-        return 25
-      }
+      next: `?offset=0&amount=${3}`
     },
     meta: {
       current: 0,
@@ -19,6 +16,9 @@ function initPayload () {
     errors: {
       message: [],
       status: 'OK'
+    },
+    getDefaultAmount: function () {
+      return 25
     },
     errorflag: false
   }

--- a/src/components/ComponentsList.vue
+++ b/src/components/ComponentsList.vue
@@ -57,7 +57,7 @@
         </transition-group>
 
         <tr v-if="showPaginatorClick">
-          <div id="paginator" style="text-align: center;" @click="getMore()"> Hämta fler </div>
+          <div id="paginator" style="text-align: center;" @click="getMore()"><a class="button is-primary">Primary</a></div>
         </tr>
 
 
@@ -83,13 +83,9 @@
         reverse: 1,
         showPaginatorClick: true,
         searching: false,
-        payload: {
-          links: {
-            next: '?offset=0&amount=5' // first "page"/segment/increment to retrieve
-          }
+        payload: null,
         }
-      }
-    },
+      },
 
     /* Fetches signed components from the database and puts them in components */
     mounted () {
@@ -170,7 +166,6 @@
       },
 
       getNextSearchQuery () {
-        console.log("next search is ran on : " + this.searchComponents)
         axios.get(this.$baseAPI + 'components/search/' + this.searchComponents + '/' + this.payload.links.next)
           .then(response => {
             this.payload = response.data

--- a/src/components/ComponentsList.vue
+++ b/src/components/ComponentsList.vue
@@ -57,7 +57,7 @@
         </transition-group>
 
         <tr v-if="showPaginatorClick">
-          <div id="paginator" style="text-align: center;" @click="getMore()"><a class="button is-primary">Primary</a></div>
+          <div id="paginator" style="text-align: center;" @click="getMore()"><a class="button is-primary">Hämta in fler</a></div>
         </tr>
 
 

--- a/src/components/ComponentsList.vue
+++ b/src/components/ComponentsList.vue
@@ -156,6 +156,16 @@
         axios.get(this.$baseAPI + 'components/' + this.payload.links.next)
           .then(response => {
             this.payload = response.data
+            // FIXME: TODO: ta bort nedanstående, endast debug-info
+        {
+        console.log('response.links = {')
+          for (let a in response.data.links) {
+         // console.log(a + ': ' + respoonse.links[a] + ',')
+         console.log(a + ":" + response.data.links[a])
+          }
+        console.log('}')
+        }
+        // FIXME: TODO: TA BORT OVANSTÅENDE
             this.components = [...this.components, ...this.payload.items]
             if (this.components.length === this.payload.meta.count) {
               this.showPaginatorClick = null

--- a/src/components/ComponentsSign.vue
+++ b/src/components/ComponentsSign.vue
@@ -40,7 +40,7 @@
         </transition-group>
 
         <tr v-if="showPaginatorClick">
-          <div id="paginator" style="text-align: center;" @click="getMore()"><a class="button is-primary">Primary</a></div>
+          <div id="paginator" style="text-align: center;" @click="getMore()"><a class="button is-primary">Hämta in fler</a></div>
         </tr>
 
         </tbody>

--- a/src/components/ComponentsSign.vue
+++ b/src/components/ComponentsSign.vue
@@ -30,12 +30,19 @@
         </tr>
         </thead>
         <tbody>
-        <tr v-for="component in components" @click="displayComponent(component)">
-          <td scope="row" data-label="Component">{{ component.componentName }}</td>
-          <td scope="row" data-label="Version">{{ component.componentVersion }}</td>
-          <td scope="row" data-label="Created">{{ component.dateCreated }}</td>
-          <td scope="row" data-label="Last edited">{{ component.lastEdited }}</td>
+        <transition-group name="list" appear>
+          <tr v-for="component in components" @click="displayComponent(component)" v-bind:key="component" class="list-item">
+            <td scope="row" data-label="Component">{{ component.componentName }}</td>
+            <td scope="row" data-label="Version">{{ component.componentVersion }}</td>
+            <td scope="row" data-label="Created">{{ component.dateCreated }}</td>
+            <td scope="row" data-label="Last edited">{{ component.lastEdited }}</td>
+          </tr>
+        </transition-group>
+
+        <tr v-if="showPaginatorClick">
+          <div id="paginator" style="text-align: center;" @click="getMore()"> Hämta fler </div>
         </tr>
+
         </tbody>
       </table>
     </div>
@@ -52,46 +59,92 @@
         components: [],
         component: null,
         componentVersion: null,
-        searchComponents: '',
+        searchComponents: null,
         sorted: '',
-        reverse: 1
+        reverse: 1,
+        showPaginatorClick: true,
+        searching: false,
+        payload: {
+          links: {
+            next: '?offset=0&amount=5' // first "page"/segment/increment to retrieve
+          }
+        }
       }
     },
     /* Fetches unsigned components from the database and puts them in components */
     mounted () {
-      this.getAllPending()
+      // TODO: getNext()
+      this.getNext()
     },
 
     methods: {
+      getMore () {
+        if (this.searching === false) {
+          this.getNext()
+        } else {
+          this.getNextSearchQuery()
+        }
+      },
       getAllPending () {
         axios.get(this.$baseAPI + 'components/pending')
           .then(response => {
             this.components = response.data
           })
       },
+      // TODO: behöver städa upp. men huvud funktionalitet i sök + hämtning av data för / och /pending, samt /search och /pending/search
       /**
        * Searches for unsigned components from the database matching the search-criteria
        */
       searchComponent () {
-        // TODO Implement method
+        this.searching = true
+        this.payload = this.$initPayload()
+        this.showPaginatorClick = true
         if (this.searchComponents.length === 0) {
-          this.getAllPending()
+          this.searching = false
+          this.showPaginatorClick = true
+          this.components = []
+          this.getNext()
           return
         }
-        if (this.searchComponents !== 0 || this.searchComponents !== null || this.searchComponents !== '') {
-          axios.get(this.$baseAPI + 'components/search/' + this.searchComponents).then(response => {
+        if ((this.searchComponents.length !== 0) && (this.searchComponents !== null) && (this.searchComponents !== '')) {
+          const path = `components/pending/search/${this.searchComponents}/${this.payload.links.next}`
+          console.log(path)
+          axios.get(this.$baseAPI + path).then(response => {
             console.log(response.data)
             if (response.data != null) {
-              this.components = response.data
+              this.payload = response.data
+              this.components = [...this.payload.items]
             } else {
               this.message = 'No component found!'
             }
           })
-        } else {
-          this.getAllPending()
         }
       },
-
+      getNext () {
+        axios.get(this.$baseAPI + 'components/pending/' + this.payload.links.next)
+          .then(response => {
+            this.payload = response.data
+            this.components = [...this.components, ...this.payload.items]
+            if (this.components.length === this.payload.meta.count) {
+              this.showPaginatorClick = null
+            } else {
+              this.showPaginatorClick = true
+            }
+          })
+      },
+      getNextSearchQuery () {
+        console.log("next search is ran on : " + this.searchComponents)
+        axios.get(this.$baseAPI + 'components/pending/search/' + this.searchComponents + '/' + this.payload.links.next)
+          .then(response => {
+            this.payload = response.data
+            this.components = [...this.components, ...this.payload.items]
+            if (this.components.length === this.payload.meta.count) {
+              this.showPaginatorClick = null
+            } else {
+              this.showPaginatorClick = true
+            }
+          })
+      },
       /**
        * Opens the view for signing a specific component with id id.
        * @param component The component to be signed

--- a/src/components/ComponentsSign.vue
+++ b/src/components/ComponentsSign.vue
@@ -40,7 +40,7 @@
         </transition-group>
 
         <tr v-if="showPaginatorClick">
-          <div id="paginator" style="text-align: center;" @click="getMore()"> Hämta fler </div>
+          <div id="paginator" style="text-align: center;" @click="getMore()"><a class="button is-primary">Primary</a></div>
         </tr>
 
         </tbody>
@@ -64,16 +64,13 @@
         reverse: 1,
         showPaginatorClick: true,
         searching: false,
-        payload: {
-          links: {
-            next: '?offset=0&amount=5' // first "page"/segment/increment to retrieve
-          }
-        }
+        payload: null
       }
     },
     /* Fetches unsigned components from the database and puts them in components */
     mounted () {
       // TODO: getNext()
+      this.$initPayload()
       this.getNext()
     },
 

--- a/src/components/ComponentsSign.vue
+++ b/src/components/ComponentsSign.vue
@@ -70,7 +70,7 @@
     /* Fetches unsigned components from the database and puts them in components */
     mounted () {
       // TODO: getNext()
-      this.$initPayload()
+      this.payload = this.$initPayload()
       this.getNext()
     },
 

--- a/src/components/ComponentsSign.vue
+++ b/src/components/ComponentsSign.vue
@@ -147,7 +147,7 @@
        * @param component The component to be signed
        */
       displayComponent (component) {
-        console.log(`Component id is ${component}`)
+        console.log(`Component id is ${component.id}`)
         this.$router.push({ name: 'components_pending_id', params: { id: component.id } })
       },
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,10 +3,11 @@ import App from './App'
 import router from './router'
 import 'bulma/css/bulma.css'
 import 'font-awesome/css/font-awesome.css'
-
+let [initPayload] = require('../backend/routes/payloadConfig')
 Vue.config.productionTip = false
 
 Vue.prototype.$baseAPI = 'http://localhost:3000/'
+Vue.prototype.$initPayload = initPayload
 
 let main = new Vue({
   el: '#app',

--- a/src/payloadConfig.js
+++ b/src/payloadConfig.js
@@ -25,4 +25,4 @@ function initPayload () {
   return payload
 }
 
-module.exports = [initPayload]
+module.exports = [initPayload, NOTSIGNED, SIGNED]

--- a/src/payloadConfig.js
+++ b/src/payloadConfig.js
@@ -25,4 +25,4 @@ function initPayload () {
   return payload
 }
 
-module.exports = [initPayload, NOTSIGNED, SIGNED]
+module.exports = [initPayload]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -56,7 +56,7 @@ export default new Router({
       component: ComponentsHome
     },
     {
-      path: '/components/:id(\\d+)',
+      path: '/components/component/:id(\\d+)',
       name: 'components_id',
       component: Component
     },

--- a/src/views/Component.vue
+++ b/src/views/Component.vue
@@ -285,7 +285,7 @@
      * then fetch licenses, products and projects
      */
     mounted () {
-      axios.get(this.$baseAPI + 'components/' + this.$route.params.id)
+      axios.get(this.$baseAPI + 'components/component/' + this.$route.params.id)
         .then(response => {
           this.component = response.data
           this.origComment = this.component.comment

--- a/src/views/SignComponent.vue
+++ b/src/views/SignComponent.vue
@@ -86,7 +86,7 @@
     },
 
     mounted () {
-      const pendingURI = 'components/' + this.$route.params.id
+      const pendingURI = 'components/component/' + this.$route.params.id
       axios.get(this.$baseAPI + pendingURI)
         .then(response => {
           this.component = response.data


### PR DESCRIPTION
# Beskrivning
Tillaggt ny fil, som importeras i main.js. Denna innehåller en statisk funktion, (se OMD - factory pattern-stil) för skapande av ett tomt payload-objekt, fast med inställda default query parametrar för offset (kursör i databasen) samt amount (... antalet hämtade). Dessa är inställda på väldigt små värden just nu, för att man enkelt ska kunna testa och se att den faktiskt fungerar (dvs, hämta in 3 åt gången, för att slippa ha så mycket i databasen vid test - ÄNDRA detta vid senare tillfället).

Uppdaterat components-resursen så att denna funktionalitet är implementerad på den pathen, för respektive del-resurs.

Resurser:
- /components/:id  ---> /components/component/:id 
- /search/:id  är path för sökning på components som är signerade, med namn = id
- /pending/search/:id/?offset=X  är path för sökning på components som är pending, med namn = id


Denna ändrades främst för att den stör andra resurser. Eftersom /components/:id är en "kortare" path, så kommer den gå "före" vid anrop till, till exempel /components/search/:id och då är vi tillbaka i if-sats-helvetet igen.

För beskrivning för API-dokumentation gäller då följande:
Vill man hämta in osignerade komponenter, görs ett GET request till /components/?offset=X&amount=Y
Och det svar man får är följande:

```javascript
  const payload = {
    items: [], // 
    links: {
      prev: '',
      current: `?offset=0&amount=${3}`,
      next: `?offset=0&amount=${3}`,
      getDefaultAmount: function () {
        return 25
      }
    },
    meta: { // meta-information som totala mängd, och nuvarande offset-mängd
      current: 0,
      count: 0
    },
    errors: { // errors, som inte kastar exception kan sparas här
      message: [],
      status: 'OK'
    },
    errorflag: false // en flagga för att se ifall errors har fått nåt nytt meddelande
  }
```

Den här strukturen följer den specifikation som http://jsonapi.org beskriver. 

items[] populeras med komponenter. Kontext-datan fylls i links, så att dessa kan användas till den path/resurs man befinner sig vid.

Så i det här fallet, om man hämtar från /components/?offset=0&amount=3 så kommer links objektet, i payload se ut på följande sätt:
```javascript
      response.links = {
        prev: `?offset=0&amount=3`,
        current: `?offset=0&amount=3`,
        next: `?offset=3&amount=3`
      }
```
Vid nästa anrop till backend, görs då med h.a. response.links.next, då blir pathen:
/components/ + response.links.next
Eller i en Vue komponent blir det
axios.get(this.$baseAPI + 'components/' + this.payload.links.next)

I backend har jag skrivit så att den beräknar totala mängden element i tabellen, så att links objektet uppdateras dynamisk, så att man inte kan få ett hämta-overflow så att säga. Backend ger dynamiskt länkar till frontend att hämta ut mer data, och när det inte finns mer data, så stannar kursören (i det här fallet linksobjektet). 

- [x] Brytande förändring (fix eller funktion som skulle leda till att befintlig funktionalitet inte fungerar som förväntat)
- [x] Denna ändring kräver en dokumentationsuppdatering

# Hur har detta blivit testat?

- [x] Testat genom användade, inga tester skrivna

- [x] Min kod följer stilriktlinjerna för detta projekt
- [x] Jag har utfört en egen granskning av min egen kod
- [x] Jag har kommenterat min kod, särskilt i svårförståeliga områden

